### PR TITLE
update camera optimizer to match nerfstudio

### DIFF
--- a/in2n/in2n_config.py
+++ b/in2n/in2n_config.py
@@ -43,15 +43,11 @@ in2n_method = MethodSpecification(
                 train_num_rays_per_batch=16384,
                 eval_num_rays_per_batch=4096,
                 patch_size=32,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                    scheduler=ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
-                ),
             ),
             model=InstructNeRF2NeRFModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
                 use_lpips=True,
+                camera_optimizer=CameraOptimizerConfig(mode="SO3xR3"),
             ),
             ip2p_use_full_precision=True
         ),
@@ -63,6 +59,10 @@ in2n_method = MethodSpecification(
             "fields": {
                 "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
                 "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
+            },
+            "camera_opt": {
+                "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
@@ -86,15 +86,11 @@ in2n_method_small = MethodSpecification(
                 train_num_rays_per_batch=16384,
                 eval_num_rays_per_batch=4096,
                 patch_size=32,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                    scheduler=ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
-                ),
             ),
             model=InstructNeRF2NeRFModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
                 use_lpips=True,
+                camera_optimizer=CameraOptimizerConfig(mode="SO3xR3"),
             ),
             ip2p_use_full_precision=False,
         ),
@@ -106,6 +102,10 @@ in2n_method_small = MethodSpecification(
             "fields": {
                 "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
                 "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
+            },
+            "camera_opt": {
+                "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
@@ -129,15 +129,11 @@ in2n_method_tiny = MethodSpecification(
                 train_num_rays_per_batch=4096,
                 eval_num_rays_per_batch=4096,
                 patch_size=1,
-                camera_optimizer=CameraOptimizerConfig(
-                    mode="SO3xR3",
-                    optimizer=AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                    scheduler=ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
-                ),
             ),
             model=InstructNeRF2NeRFModelConfig(
                 eval_num_rays_per_chunk=1 << 15,
                 use_lpips=False,
+                camera_optimizer=CameraOptimizerConfig(mode="SO3xR3"),
             ),
             ip2p_use_full_precision=False,
         ),
@@ -149,6 +145,10 @@ in2n_method_tiny = MethodSpecification(
             "fields": {
                 "optimizer": AdamOptimizerConfig(lr=1e-2, eps=1e-15),
                 "scheduler": ExponentialDecaySchedulerConfig(lr_final=0.0001, max_steps=200000),
+            },
+            "camera_opt": {
+                "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),

--- a/in2n/in2n_datamanager.py
+++ b/in2n/in2n_datamanager.py
@@ -61,13 +61,7 @@ class InstructNeRF2NeRFDataManager(VanillaDataManager):
         )
         self.iter_train_image_dataloader = iter(self.train_image_dataloader)
         self.train_pixel_sampler = self._get_pixel_sampler(self.train_dataset, self.config.train_num_rays_per_batch)
-        self.train_camera_optimizer = self.config.camera_optimizer.setup(
-            num_cameras=self.train_dataset.cameras.size, device=self.device
-        )
-        self.train_ray_generator = RayGenerator(
-            self.train_dataset.cameras.to(self.device),
-            self.train_camera_optimizer,
-        )
+        self.train_ray_generator = RayGenerator(self.train_dataset.cameras.to(self.device),)
 
         # pre-fetch the image batch (how images are replaced in dataset)
         self.image_batch = next(self.iter_train_image_dataloader)

--- a/in2n/in2n_pipeline.py
+++ b/in2n/in2n_pipeline.py
@@ -142,7 +142,7 @@ class InstructNeRF2NeRFPipeline(VanillaPipeline):
                 current_index = self.datamanager.image_batch["image_idx"][current_spot]
 
                 # get current camera, include camera transforms from original optimizer
-                camera_transforms = self.datamanager.train_camera_optimizer(current_index.unsqueeze(dim=0))
+                camera_transforms = self.model.camera_optimizer(current_index.unsqueeze(dim=0))
                 current_camera = self.datamanager.train_dataparser_outputs.cameras[current_index].to(self.device)
                 current_ray_bundle = current_camera.generate_rays(torch.tensor(list(range(1))).unsqueeze(-1), camera_opt_to_camera=camera_transforms)
 


### PR DESCRIPTION
camera optimizer has been move to model in https://github.com/nerfstudio-project/nerfstudio/pull/2092

Currently, it will throw an error if we want to init it in datamanager as before:
```
TypeError: RayGenerator.__init__() takes 2 positional arguments but 3 were given                                        
```