### PR TITLE
update scheduler for camera optimizer

### DIFF
--- a/in2n/in2n_config.py
+++ b/in2n/in2n_config.py
@@ -62,7 +62,7 @@ in2n_method = MethodSpecification(
             },
             "camera_opt": {
                 "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=5000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
@@ -105,7 +105,7 @@ in2n_method_small = MethodSpecification(
             },
             "camera_opt": {
                 "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=5000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
@@ -148,7 +148,7 @@ in2n_method_tiny = MethodSpecification(
             },
             "camera_opt": {
                 "optimizer": AdamOptimizerConfig(lr=6e-4, eps=1e-8, weight_decay=1e-2),
-                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=200000),
+                "scheduler": ExponentialDecaySchedulerConfig(lr_final=6e-6, max_steps=5000),
             },
         },
         viewer=ViewerConfig(num_rays_per_chunk=1 << 15),


### PR DESCRIPTION
Hopefully this can address the issue https://github.com/ayaanzhaque/instruct-nerf2nerf/issues/60

The lr of camera optimizer will be ignored when loading from a checkpoint. Using large step in scheduler (`max_steps=200000`) leads to extra large lr on cameras, which leads to bad results when editing the scene.

Switching to a much smaller `max_steps=5000` can ask it to always use `lr_final`