### PR TITLE
Continues Editing with Sequential Text Prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is the official implementation of [Instruct-NeRF2NeRF](https://instruct-ner
 
 ![teaser](imgs/in2n_teaser.png)
 
+# Continuous Editing
+Use `update_imgs.py` to load an edited scene and update input images. Then, use a new prompt to start a new round of editing.
+
 # Installation
 
 ## 1. Install Nerfstudio dependencies

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
+
+# Continuous Editing
+Use `update_imgs.py` to load an edited scene and update input images. Then, use a new prompt to start a new round of editing.
+
+
+
+
+
+
+
+
+
+
+
 # Instruct-NeRF2NeRF: Editing 3D Scenes with Instructions
 
 This is the official implementation of [Instruct-NeRF2NeRF](https://instruct-nerf2nerf.github.io/).
 
 ![teaser](imgs/in2n_teaser.png)
 
-# Continuous Editing
-Use `update_imgs.py` to load an edited scene and update input images. Then, use a new prompt to start a new round of editing.
 
 # Installation
 

--- a/get_clip.py
+++ b/get_clip.py
@@ -1,0 +1,30 @@
+from metrics.clip_metrics import ClipSimilarity
+from PIL import Image
+import torchvision.transforms as transforms
+clip_model = ClipSimilarity(name="ViT-B/32")  # Choose the model type
+print(clip_model)
+
+image_0 = Image.open("res/orig-frame_00005.jpg").convert("RGB")
+image_1 = Image.open("res/bald-frame_00005.jpg").convert("RGB")
+text_0 = "“a photograph of a man"
+text_1 = "“a photograph of a clown"
+
+
+transform = transforms.Compose([
+    transforms.ToTensor(),  # Convert image to PyTorch tensor
+    transforms.Resize((224, 224)),  
+])
+
+image_0 = transform(image_0).unsqueeze(0)  # Add batch dimension
+image_1 = transform(image_1).unsqueeze(0)  
+
+
+sim_0, sim_1, sim_direction, sim_image = clip_model.forward(
+    image_0, image_1, text_0, text_1
+)
+
+print(f"Similarity between image 0 and text 0: {sim_0.item()}")
+print(f"Similarity between image 1 and text 1: {sim_1.item()}")
+print(f"Directional similarity: {sim_direction.item()}")
+print(f"Image-to-image similarity: {sim_image.item()}")
+

--- a/update_imgs.py
+++ b/update_imgs.py
@@ -1,0 +1,92 @@
+import nerfstudio as ns
+import torch
+import torch.nn as nn
+from nerfstudio.models.base_model import Model
+from nerfstudio.models.nerfacto import NerfactoModel
+from nerfstudio.utils.eval_utils import eval_setup
+from pathlib import Path
+
+import nerfstudio as ns
+import torch
+import torch.nn as nn
+from nerfstudio.models.base_model import Model
+from nerfstudio.models.nerfacto import NerfactoModel
+from nerfstudio.utils.eval_utils import eval_setup
+from pathlib import Path
+
+from PIL import Image
+import torchvision.transforms as transforms
+
+import itertools
+
+def find_length_of_original_iterable(cycle_iterator):
+    seen = set()
+    for item in cycle_iterator:
+        if item in seen:
+            return len(seen)
+        seen.add(item)
+
+
+
+
+
+def main():
+    
+    check_point = '/home/kirakiraakira/cs236/instruct-nerf2nerf/outputs/bear/in2n-small/2023-12-04_031034/config.yml'
+    
+    check_point = Path(check_point)
+    config, pipeline, checkpoint_path, _ = eval_setup(check_point)
+    model=pipeline.model
+    print('pipeline datamanager',pipeline.datamanager)
+    print("model outputs for camera ray bundle",model.get_outputs_for_camera_ray_bundle)
+    print('pipeline train indices order',pipeline.train_indices_order)
+    length_of_original_list = find_length_of_original_iterable(pipeline.train_indices_order)
+    print("len of pipeline train indices order:",length_of_original_list)  # This will print 3, the length of my_list
+    # print("len of pipeline train indices order:",len(pipeline.train_indices_order))
+    # Rest of your code4
+    for i in range(length_of_original_list):
+        current_spot = next(pipeline.train_indices_order)
+        print('spot:',current_spot)
+        # get original image from dataset
+        original_image = pipeline.datamanager.original_image_batch["image"][current_spot].to(pipeline.device)
+        # generate current index in datamanger
+        current_index = pipeline.datamanager.image_batch["image_idx"][current_spot]
+        print('index:',current_index,current_index.shape)
+        
+        # get current camera, include camera transforms from original optimizer
+        camera_transforms = pipeline.model.camera_optimizer(current_index.unsqueeze(dim=0))
+        print('index_to_camera_transforms:',current_index,camera_transforms)
+        current_camera = pipeline.datamanager.train_dataparser_outputs.cameras[current_index].to(pipeline.device)
+        current_ray_bundle = current_camera.generate_rays(torch.tensor(list(range(1))).unsqueeze(-1), camera_opt_to_camera=camera_transforms)
+
+        # get current render of nerf
+        original_image = original_image.unsqueeze(dim=0).permute(0, 3, 1, 2)
+        camera_outputs = pipeline.model.get_outputs_for_camera_ray_bundle(current_ray_bundle)
+        rendered_image = camera_outputs["rgb"].unsqueeze(dim=0).permute(0, 3, 1, 2)
+        print(i,rendered_image.shape)
+
+        # Save the original image
+        original_image_tensor = transforms.ToPILImage()(original_image.squeeze(0).cpu())
+        original_image_tensor = original_image_tensor.convert("RGB")
+        original_image_path = f"{i}_original_image.png"
+        #original_image_tensor.save(original_image_path)
+
+        # Sve the rendered image
+        image_tensor = transforms.ToPILImage()(rendered_image.squeeze(0).cpu())  # Remove the batch dimension
+        image_tensor = image_tensor.convert("RGB")
+
+        # Save the image
+        image_path = str(i)+"_output_image.png"  # You can choose any desired file path and format
+        current_index = int(current_index)
+        current_index+=1
+        formatted_index = f"{current_index:02d}"
+        ori_file_path='/home/kirakiraakira/cs236/instruct-nerf2nerf/data/nerfstudio/bear/updated_images/frame_000'+formatted_index +'.jpg'
+        image_tensor.save(ori_file_path)
+    # current_index = torch.tensor(58)
+    # print(current_index.shape)
+    # camera_transforms = pipeline.model.camera_optimizer(current_index.unsqueeze(dim=0))
+    # print(camera_transforms)
+
+
+if __name__ == '__main__':
+    main()

--- a/update_imgs.py
+++ b/update_imgs.py
@@ -38,12 +38,9 @@ def main():
     config, pipeline, checkpoint_path, _ = eval_setup(check_point)
     model=pipeline.model
     print('pipeline datamanager',pipeline.datamanager)
-    print("model outputs for camera ray bundle",model.get_outputs_for_camera_ray_bundle)
     print('pipeline train indices order',pipeline.train_indices_order)
     length_of_original_list = find_length_of_original_iterable(pipeline.train_indices_order)
-    print("len of pipeline train indices order:",length_of_original_list)  # This will print 3, the length of my_list
-    # print("len of pipeline train indices order:",len(pipeline.train_indices_order))
-    # Rest of your code4
+    print("len of pipeline train indices order:",length_of_original_list)  
     for i in range(length_of_original_list):
         current_spot = next(pipeline.train_indices_order)
         print('spot:',current_spot)
@@ -55,7 +52,7 @@ def main():
         
         # get current camera, include camera transforms from original optimizer
         camera_transforms = pipeline.model.camera_optimizer(current_index.unsqueeze(dim=0))
-        print('index_to_camera_transforms:',current_index,camera_transforms)
+        
         current_camera = pipeline.datamanager.train_dataparser_outputs.cameras[current_index].to(pipeline.device)
         current_ray_bundle = current_camera.generate_rays(torch.tensor(list(range(1))).unsqueeze(-1), camera_opt_to_camera=camera_transforms)
 
@@ -63,7 +60,7 @@ def main():
         original_image = original_image.unsqueeze(dim=0).permute(0, 3, 1, 2)
         camera_outputs = pipeline.model.get_outputs_for_camera_ray_bundle(current_ray_bundle)
         rendered_image = camera_outputs["rgb"].unsqueeze(dim=0).permute(0, 3, 1, 2)
-        print(i,rendered_image.shape)
+        
 
         # Save the original image
         original_image_tensor = transforms.ToPILImage()(original_image.squeeze(0).cpu())
@@ -72,20 +69,17 @@ def main():
         #original_image_tensor.save(original_image_path)
 
         # Sve the rendered image
-        image_tensor = transforms.ToPILImage()(rendered_image.squeeze(0).cpu())  # Remove the batch dimension
+        image_tensor = transforms.ToPILImage()(rendered_image.squeeze(0).cpu())  
         image_tensor = image_tensor.convert("RGB")
 
         # Save the image
-        image_path = str(i)+"_output_image.png"  # You can choose any desired file path and format
+        image_path = str(i)+"_output_image.png"  
         current_index = int(current_index)
         current_index+=1
         formatted_index = f"{current_index:02d}"
         ori_file_path='/home/kirakiraakira/cs236/instruct-nerf2nerf/data/nerfstudio/bear/updated_images/frame_000'+formatted_index +'.jpg'
         image_tensor.save(ori_file_path)
-    # current_index = torch.tensor(58)
-    # print(current_index.shape)
-    # camera_transforms = pipeline.model.camera_optimizer(current_index.unsqueeze(dim=0))
-    # print(camera_transforms)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### Summary:

I've introduced a new feature to the `instruct-nerf2nerf` project that enables continuesly editing 3D NeRF scenes using text prompts. This function allows for the loading of previously edited NeRF scenes, re-rendering them from specific locations and poses to match the original dataset. And then use the next prompt to edit the new scene. The key here is the ability to perform continuous and sequential text prompt editing.

#### Detailed Explanation:

**Feature Overview**:

- **Scene Loading**: This function can load an edited 3D NeRF scene.
- **Re-rendering Capability**: It re-renders images corresponding to the locations and poses from the original dataset.
- **Sequential Text Prompt Editing**: Users can now edit scenes continuously with text prompts. This is particularly useful for complex long prompts, where edits can be applied in a sequential manner.

**Use Cases**:

- **Sequential Editing**: Ideal for complex scene modifications where a single text prompt may not suffice.
- **Iterative Creative Process**: Artists and creators can now iteratively refine their scenes, adding depth and detail with each edit.

**Implementation:**

- For simplicity, I changed the `train validation split ratio` from the nerf library to 1.0. The original value is 0.9. Using 0.9 will cause the index of the images to shuffle, which can be solve by using a dictionary to store the index and the original file name.
- For naming the new images, I set it to be `current_index:02d`, which needs to change if the total number of images exceeds 100.

**Results of Continues Editing:**
<img width="892" alt="faces" src="https://github.com/ayaanzhaque/instruct-nerf2nerf/assets/64133268/10273404-e4a3-4778-be1f-9df9d851a0d4">

I believe this feature will be a valuable addition to the `instruct-nerf2nerf` project, offering users more control and creative freedom in their 3D scene generation and editing endeavors.

