### PR TITLE
Pin Nerfstudio Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 name = "in2n"
 version = "0.1.0"
 
+
 dependencies=[
-    "nerfstudio>=0.3.0",
+    "nerfstudio @ git+https://github.com/nerfstudio-project/nerfstudio.git@ca9e6c1",
     "clip @ git+https://github.com/openai/CLIP.git",
     "diffusers>=0.14.0.dev0",
     "transformers>=4.26.1",


### PR DESCRIPTION
This PR pins the latest known working branch of nerfstudio. This helps avoid issues like #85 and #72 

Example: nerfstudio viewer was recently [updated](https://github.com/nerfstudio-project/nerfstudio/commit/451a70c1f37f0d080059a90c2dbba17f843bec5e) to use viser, which breaks parts of instruct-nerf2nerf repo. 

```
from nerfstudio.viewer.server.viewer_elements import ViewerNumber, ViewerText
```
throws

_ModuleNotFoundError: No module named 'nerfstudio.viewer.server'_


This PR pins nerfstudio to the[ commit prior to that update](https://github.com/nerfstudio-project/nerfstudio/commit/ca9e6c12948ba716909ee74b463b5c82d3578099) to insure instruct-nerf2nerf installation works out of the box.